### PR TITLE
fix a compatibility issue

### DIFF
--- a/lab0/tools/kernel.ld
+++ b/lab0/tools/kernel.ld
@@ -12,6 +12,7 @@ SECTIONS
     . = BASE_ADDRESS;
 
     .text : {
+        *entry.o(.text.kern_entry .text .stub .text.* .gnu.linkonce.t.*)
         *(.text.kern_entry .text .stub .text.* .gnu.linkonce.t.*)
     }
 


### PR DESCRIPTION
using GNU make 4.2.1 and ld 2.34.0 on SUSE
will make the compilation of kernel fail
due to wrong sorting. Have to make explicit
the entry point of kernel in the linker script.